### PR TITLE
修复SIGN生成错误问题

### DIFF
--- a/upyun.class.php
+++ b/upyun.class.php
@@ -238,7 +238,8 @@ class UpYun {
 	*/
 	private function sign($method, $uri, $date, $length){/*{{{*/
         //$uri = urlencode($uri);
-		$sign = "{$method}&{$uri}&{$date}&{$length}&{$this->_password}";
+        $md5password = md5($this->_password);
+		$sign = "{$method}&{$uri}&{$date}&{$length}&{$md5password}";
 		return 'UpYun '.$this->_username.':'.md5($sign);
 	}/*}}}*/
 


### PR DESCRIPTION
文档：http://docs.upyun.com/api/rest_api/
“将 PASSWORD md5 之后（我们暂且将其记作 PASSWORD_MD5）”

此处SDK没有在生成sign的function MD5密码

$sign = "{$method}&{$uri}&{$date}&{$length}&{$this->_password}";

=>

$md5password = md5($this->_password);
$sign = "{$method}&{$uri}&{$date}&{$length}&{$md5password}";